### PR TITLE
Add Piscine availability check

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".StatusActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Ab42checks" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/ab42checks/MainActivity.kt
+++ b/app/src/main/java/com/example/ab42checks/MainActivity.kt
@@ -1,9 +1,7 @@
 package com.example.ab42checks
 
+import android.content.Intent
 import android.os.Bundle
-import android.webkit.WebChromeClient
-import android.webkit.WebSettings
-import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
 import com.example.ab42checks.databinding.ActivityMainBinding
 import java.net.HttpURLConnection
@@ -22,49 +20,49 @@ class MainActivity : AppCompatActivity() {
 
         setSupportActionBar(binding.toolbar)
 
-        setupWebView()
-        loadHtml()
-    }
-
-    private fun setupWebView() {
-        binding.webview.apply {
-            settings.javaScriptEnabled = true
-            settings.domStorageEnabled = true
-            settings.cacheMode = WebSettings.LOAD_NO_CACHE
-            webViewClient = WebViewClient()
-            webChromeClient = WebChromeClient()
+        binding.reloadButton.setOnClickListener { checkPiscine() }
+        binding.checkStatusButton.setOnClickListener {
+            startActivity(Intent(this, StatusActivity::class.java))
         }
+
+        checkPiscine()
     }
 
-    private fun loadHtml() {
+    private fun checkPiscine() {
+        binding.statusText.text = "Loading..."
         thread {
             try {
                 val url = URL("https://apply.42abudhabi.ae/users/1225298/id_checks_users")
                 val connection = url.openConnection() as HttpURLConnection
                 connection.requestMethod = "GET"
-
-                // Only required headers — avoid unnecessary pseudo-headers
                 connection.setRequestProperty("accept", "text/html,application/xhtml+xml,application/xml;q=0.9")
                 connection.setRequestProperty("accept-encoding", "gzip, deflate, br")
                 connection.setRequestProperty("accept-language", "en-US,en;q=0.9")
                 connection.setRequestProperty("cache-control", "no-cache")
                 connection.setRequestProperty(
                     "cookie",
-                    "_scid=noOSqzHmjYqvpfWkVsGDR4qYXiqs703s; _fbp=fb.1.1749910519931.318927756812476318; _tt_enable_cookie=1; _ttp=01JXQCQ107NWE8M9S3X0QG1456_.tt.1; cookieconsent_status=allow; _gid=GA1.2.581311328.1752448607; _ScCbts=%5B%5D; _sctr=1%7C1752436800000; locale=en; _gcl_au=1.1.965288889.1749910519.579472200.1752486232.1752486233; _admissions_session_production=da457ae5ca6ae36073dff5d9e368bc4f; _scid_r=ogOSqzHmjYqvpfWkVsGDR4qYXiqs703sEbmQrw; _ga=GA1.1.1596495760.1749910520; _ga_8M0TZSR8V1=GS2.1.s1752486212\$o6\$g1\$t1752487112\$j51\$l0\$h2104396700; _ga_6H0SY0TE1H=GS2.1.s1752486212\$o6\$g1\$t1752487112\$j51\$l0\$h0; ttcsid=1752486212829::rTLIzKr-CyDZx_hOdhfw.5.1752487113580; ttcsid_BTG7E331811BQC941EDG=1752486212829::H0Kntb78IEXcWFdcqwU3.5.1752487113806; ttcsid_CPHGJRJC77UAVM1484PG=1752486212830::VfLuXLo3eCPLEA_boFsY.5.1752487113806; ttcsid_CQB3KEBC77UCUPKFUIH0=1752486212909::D5bsCp5FXkK9B4B9SRsM.5.1752487113806; ph_phc_w0Uj0THoEoBYOEhEmdFtz36tIi21gTdD7eINnBpF3Dc_posthog=%7B%22distinct_id%22%3A%2201976ecb-8511-7a9a-83c8-013651896d52%22%2C%22%24sesid%22%3A%5Bnull%2Cnull%2Cnull%5D%2C%22%24initial_person_info%22%3A%7B%22r%22%3A%22https%3A%2F%2Fwww.google.com%2F%22%2C%22u%22%3A%22https%3A%2F%2F42abudhabi.ae%2F%22%7D%7D"
+                    "_scid=noOSqzHmjYqvpfWkVsGDR4qYXiqs703s; _fbp=fb.1.1749910519931.318927756812476318; _tt_enable_cookie=1; _ttp=01JXQCQ107NWE8M9S3X0QG1456_.tt.1; cookieconsent_status=allow; _gid=GA1.2.581311328.1752448607; _ScCbts=%5B%5D; _sctr=1%7C1752436800000; locale=en; _gcl_au=1.1.965288889.1749910519.579472200.1752486232.1752486233; _admissions_session_production=da457ae5ca6ae36073dff5d9e368bc4f; _scid_r=ogOSqzHmjYqvpfWkVsGDR4qYXiqs703sEbmQrw; _ga=GA1.1.1596495760.1749910520; _ga_8M0TZSR8V1=GS2.1.s1752486212\$o6\$g1\$t1752487112\$j51\$l0\$h2104396700; _ga_6H0SY0TE1H=GS2.1.s1752486212\$o6\$g1\$t1752487112\$j51\$l0\$h0; ttcsi=1752486212829::rTLIzKr-CyDZx_hOdhfw.5.1752487113580; ttcsid_BTG7E331811BQC941EDG=1752486212829::H0Kntb78IEXcWFdcqwU3.5.1752487113806; ttcsid_CPHGJRJC77UAVM1484PG=1752486212830::VfLuXLo3eCPLEA_boFsY.5.1752487113806; ttcsid_CQB3KEBC77UCPKFUIH0=1752486212909::D5bsCp5FXkK9B4B9SRsM.5.1752487113806; ph_phc_w0Uj0THoEoBYOEhEmdFtz36tIi21gTdD7eINnBpF3Dc_posthog=%7B%22distinct_id%22%3A%2201976ecb-8511-7a9a-83c8-013651896d52%22%2C%22%24sesid%22%3A%5Bnull%2Cnull%2Cnull%5D%2C%22%24initial_person_info%22%3A%7B%22r%22%3A%22https%3A%2F%2Fwww.google.com%2F%22%2C%22u%22%3A%22https%3A%2F%2F42abudhabi.ae%2F%22%7D%7D"
                 )
                 connection.setRequestProperty("user-agent", "Mozilla/5.0 (Android 13; Mobile) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Mobile Safari/537.36")
 
+                val code = connection.responseCode
                 val html = connection.inputStream.bufferedReader().use { it.readText() }
                 connection.disconnect()
 
-                runOnUiThread {
-                    binding.webview.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+                val message = if (code == HttpURLConnection.HTTP_OK) {
+                    if (html.contains("There are no available piscines right now")) {
+                        "There are no available piscines right now"
+                    } else {
+                        "Available"
+                    }
+                } else {
+                    "Error: $code"
                 }
+
+                runOnUiThread { binding.statusText.text = message }
             } catch (e: Exception) {
                 e.printStackTrace()
-                runOnUiThread {
-                    binding.webview.loadData("Error: ${e.message}", "text/plain", "utf-8")
-                }
+                runOnUiThread { binding.statusText.text = "Error: ${e.message}" }
             }
         }
     }

--- a/app/src/main/java/com/example/ab42checks/StatusActivity.kt
+++ b/app/src/main/java/com/example/ab42checks/StatusActivity.kt
@@ -1,0 +1,34 @@
+package com.example.ab42checks
+
+import android.os.Bundle
+import android.webkit.WebChromeClient
+import android.webkit.WebSettings
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+import com.example.ab42checks.databinding.ActivityStatusBinding
+
+class StatusActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityStatusBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityStatusBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.statusToolbar)
+        setupWebView()
+        binding.statusWebView.loadUrl("https://42abudhabi.ae/piscine-status/")
+    }
+
+    private fun setupWebView() {
+        binding.statusWebView.apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            settings.cacheMode = WebSettings.LOAD_NO_CACHE
+            webViewClient = WebViewClient()
+            webChromeClient = WebChromeClient()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,21 +19,33 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="16dp">
 
+        <TextView
+            android:id="@+id/statusText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Loading..."
+            android:textSize="18sp" />
 
-        <WebView
-            android:id="@+id/webview"
-            android:layout_width="100dp"
-            android:layout_height="300dp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+        <Button
+            android:id="@+id/reloadButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Reload" />
+
+        <Button
+            android:id="@+id/checkStatusButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Check Status" />
+
     </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_status.xml
+++ b/app/src/main/res/layout/activity_status.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/statusToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <WebView
+        android:id="@+id/statusWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- show API response in text instead of webview
- add reload button for checking again
- add `StatusActivity` with webview for piscina status
- register new activity in manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687729414f9c832280eebcc6cadca6f6