### PR TITLE
Add piscine status check

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,6 +33,14 @@
             android:text="Loading..."
             android:textSize="18sp" />
 
+        <TextView
+            android:id="@+id/piscineStatusText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Loading..."
+            android:textSize="18sp" />
+
         <Button
             android:id="@+id/reloadButton"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- display new status for https://42abudhabi.ae/piscine-status/
- poll the new API every half second
- add second TextView for the results

## Testing
- `./gradlew tasks --all` *(fails: unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_687740c54a9083228191261e57b77d99