### PR TITLE
Add start service button and background service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"
@@ -29,6 +30,9 @@
             android:name=".StatusActivity"
             android:exported="false"
             android:theme="@style/Theme.Ab42checks" />
+        <service
+            android:name=".StatusCheckService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/ab42checks/MainActivity.kt
+++ b/app/src/main/java/com/example/ab42checks/MainActivity.kt
@@ -22,9 +22,7 @@ import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 class MainActivity: AppCompatActivity() {
-
-    private lateinit
-    var binding: ActivityMainBinding
+    private lateinit var binding: ActivityMainBinding
     private val handler = Handler(Looper.getMainLooper())
     private val pollRunnable: Runnable = object: Runnable {
         override fun run() {
@@ -34,7 +32,7 @@ class MainActivity: AppCompatActivity() {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle ? ) {
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -55,6 +53,10 @@ class MainActivity: AppCompatActivity() {
         }
         binding.checkStatusButton.setOnClickListener {
             startActivity(Intent(this, StatusActivity::class.java))
+        }
+        binding.startServiceButton.setOnClickListener {
+            val intent = Intent(this, StatusCheckService::class.java)
+            startService(intent)
         }
 
         val request = PeriodicWorkRequestBuilder < StatusCheckWorker > (15, java.util.concurrent.TimeUnit.MINUTES)
@@ -194,7 +196,6 @@ class MainActivity: AppCompatActivity() {
     }
 
     companion object {
-        private
-        const val TAG = "MainActivity"
+        private const val TAG = "MainActivity"
     }
 }

--- a/app/src/main/java/com/example/ab42checks/StatusCheckService.kt
+++ b/app/src/main/java/com/example/ab42checks/StatusCheckService.kt
@@ -1,0 +1,101 @@
+package com.example.ab42checks
+
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.concurrent.thread
+
+class StatusCheckService : Service() {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val pollRunnable = object : Runnable {
+        override fun run() {
+            checkStatus()
+            handler.postDelayed(this, 1000)
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationUtils.createChannel(this)
+        val nm = getSystemService(NotificationManager::class.java)
+        nm.notify(
+            NotificationUtils.NOTIFICATION_ID,
+            NotificationUtils.buildNotification(this, "Checking status...")
+        )
+        handler.post(pollRunnable)
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        handler.removeCallbacks(pollRunnable)
+    }
+
+    private fun checkStatus() {
+        thread {
+            try {
+                Log.d(TAG, "Calling status API")
+                val url = URL("https://apply.42abudhabi.ae/users/1225298/id_checks_users")
+                val connection = url.openConnection() as HttpURLConnection
+                connection.requestMethod = "GET"
+                connection.setRequestProperty("accept", "text/html,application/xhtml+xml,application/xml;q=0.9")
+                connection.setRequestProperty("accept-encoding", "gzip, deflate, br")
+                connection.setRequestProperty("accept-language", "en-US,en;q=0.9")
+                connection.setRequestProperty("cache-control", "no-cache")
+                connection.setRequestProperty("user-agent", "Mozilla/5.0 (Android 13; Mobile) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Mobile Safari/537.36")
+
+                val code = connection.responseCode
+                Log.d(TAG, "API response code: $code")
+                val html = connection.inputStream.bufferedReader().use { it.readText() }
+                connection.disconnect()
+
+                val message = if (code == HttpURLConnection.HTTP_OK) {
+                    if (html.contains("There are no available piscines right now")) {
+                        "There are no available piscines right now"
+                    } else {
+                        "Available"
+                    }
+                } else {
+                    "Error: $code"
+                }
+
+                if (message == "Available") {
+                    playSound()
+                }
+
+                val nm = getSystemService(NotificationManager::class.java)
+                nm.notify(
+                    NotificationUtils.NOTIFICATION_ID,
+                    NotificationUtils.buildNotification(this@StatusCheckService, message)
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Error checking status", e)
+            }
+        }
+    }
+
+    private fun playSound() {
+        try {
+            val assetFileDescriptor = assets.openFd("iphone.mp3")
+            val mediaPlayer = android.media.MediaPlayer()
+            mediaPlayer.setDataSource(assetFileDescriptor.fileDescriptor, assetFileDescriptor.startOffset, assetFileDescriptor.length)
+            mediaPlayer.isLooping = true
+            mediaPlayer.prepare()
+            mediaPlayer.start()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to play sound", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "StatusCheckService"
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -55,6 +55,13 @@
             android:layout_marginTop="8dp"
             android:text="Check Status" />
 
+        <Button
+            android:id="@+id/startServiceButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Start Service" />
+
     </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- add `StatusCheckService` with periodic polling
- update `activity_main.xml` layout with a new `Start Service` button
- wire up new button in `MainActivity` to start the background service
- register the service and required permission in the manifest

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68775ae27bd4832286aaedfed1ca35be