### PR TITLE
Convert service to foreground

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
             android:theme="@style/Theme.Ab42checks" />
         <service
             android:name=".StatusCheckService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/ab42checks/MainActivity.kt
+++ b/app/src/main/java/com/example/ab42checks/MainActivity.kt
@@ -52,7 +52,7 @@ class MainActivity: AppCompatActivity() {
         }
         binding.startServiceButton.setOnClickListener {
             val intent = Intent(this, StatusCheckService::class.java)
-            startService(intent)
+            ContextCompat.startForegroundService(this, intent)
         }
 
         // Show a sticky notification immediately and trigger an initial status check

--- a/app/src/main/java/com/example/ab42checks/StatusCheckService.kt
+++ b/app/src/main/java/com/example/ab42checks/StatusCheckService.kt
@@ -25,11 +25,8 @@ class StatusCheckService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         NotificationUtils.createChannel(this)
-        val nm = getSystemService(NotificationManager::class.java)
-        nm.notify(
-            NotificationUtils.NOTIFICATION_ID,
-            NotificationUtils.buildNotification(this, "Checking status...")
-        )
+        val notification = NotificationUtils.buildNotification(this, "Checking status...")
+        startForeground(NotificationUtils.NOTIFICATION_ID, notification)
         handler.post(pollRunnable)
         return START_STICKY
     }


### PR DESCRIPTION
## Summary
- update `StatusCheckService` to start as a foreground service
- start the service via `ContextCompat.startForegroundService`
- mark `StatusCheckService` with `foregroundServiceType`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687761f131b88322aad0b97dc1beb5fe