### PR TITLE
Make cookie edit scrollable with save button

### DIFF
--- a/app/src/main/java/com/example/ab42checks/MainActivity.kt
+++ b/app/src/main/java/com/example/ab42checks/MainActivity.kt
@@ -66,6 +66,9 @@ class MainActivity: AppCompatActivity() {
             binding.cookieInput.visibility = View.VISIBLE
             binding.saveCookieButton.visibility = View.VISIBLE
             binding.cookieInput.setText(prefs.getString("cookie", CookieStore.DEFAULT_COOKIE))
+            binding.scrollView.post {
+                binding.scrollView.fullScroll(View.FOCUS_DOWN)
+            }
         }
         binding.saveCookieButton.setOnClickListener {
             val cookie = binding.cookieInput.text.toString().replace("\$", "\\$")

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,12 +19,18 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <LinearLayout
+    <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
         android:layout_marginTop="250dp"
-        android:padding="16dp">
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
 
         <TextView
             android:id="@+id/statusText"
@@ -88,5 +94,7 @@
             android:visibility="gone" />
 
     </LinearLayout>
+
+    </ScrollView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- wrap main content in a ScrollView and include a Save Cookie button
- auto scroll to reveal Save button when editing cookie

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a917f604b083229550a213263470f9